### PR TITLE
feat: Integrate with ratelimit module

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,203 +1,99 @@
 # **Contributing to Caddy Defender**
 
-Welcome! If you want to add new responders or IP ranges to block, you're in the right place. This guide will walk you through the process.
-
----
-## **Adding New IP Ranges to Block**
-
-To add new IP ranges, you need to create a new fetcher in the `ranges/fetchers` package. Here's how:
+We welcome contributions to enhance Caddy Defender's capabilities! This guide outlines how to add new functionality through IP range sources or response handlers.
 
 ---
 
-### **1. Create a New IP Fetcher**
+## **Adding New IP Range Sources**
 
-1. **Create a New File**:
-   Create a new file in the `ranges/fetchers` directory, e.g., `my_service.go`.
+### Overview
+To block new IP ranges, you can create fetchers for different services or networks. These can be either:
+- **Static ranges**: Predefined lists of IPs/CIDRs
+- **Dynamic sources**: API-driven updates from service providers
 
-2. **Implement the Fetcher**:
-   Your fetcher must implement the `IPRangeFetcher` interface:
-   ```go
-   package fetchers
+### Implementation Steps
+1. **Create a new fetcher**  
+   - Make a new file in `ranges/fetchers`
+   - Implement the core interface with:
+     - Service name and description
+     - Range fetching logic
+     - Error handling
 
-   // MyServiceFetcher implements the IPRangeFetcher interface for MyService.
-   type MyServiceFetcher struct{}
+2. **Register your fetcher**  
+   Add your new fetcher to the main registry list
 
-   func (f MyServiceFetcher) Name() string {
-       return "MyService"
-   }
+3. **Rebuild and test**  
+   Use standard build tools to compile and verify your changes
 
-   func (f MyServiceFetcher) Description() string {
-       return "Fetches IP ranges for MyService."
-   }
-
-   func (f MyServiceFetcher) FetchIPRanges() ([]string, error) {
-       // Hardcoded IP ranges for MyService
-       return []string{
-           "203.0.113.0/24",
-           "198.51.100.0/24",
-       }, nil
-   }
-   ```
-
-   If your service provides an API to fetch IP ranges dynamically, you can use HTTP requests and JSON parsing (like in `OpenAIFetcher`).
+4. **Update documentation**  
+   Add your source to the predefined ranges list in documentation
 
 ---
 
-### **2. Add the Fetcher to the List**
+## **Creating New Response Handlers**
 
-Update the `fetchersList` in `ranges/main.go` to include your new fetcher:
+### Overview
+Response handlers determine how Caddy Defender interacts with matched requests. Common patterns include:
+- Blocking requests
+- Returning custom content
+- Triggering security workflows
 
-```go
-func main() {
-	// Define flags
-	flag.StringVar(&outputFormat, "format", "json", "Output format: json or go")
-	flag.StringVar(&outputFile, "output", "output.json", "Output file path")
-	flag.Parse()
+### Implementation Steps
+1. **Create response handler**  
+   - Make a new file in `responders`
+   - Implement the core response interface
+   - Include any configuration parameters
 
-	// Create an array of all IP range fetchers
-	fetchersList := []fetchers.IPRangeFetcher{
-		fetchers.OpenAIFetcher{},
-		fetchers.DeepSeekFetcher{},
-		fetchers.GithubCopilotFetcher{},
-		fetchers.MyServiceFetcher{}, // Add your new fetcher here
-	}
+2. **Register handler type**  
+   Add your handler to the configuration parser
 
-	// Rest of the code...
-}
-```
+3. **Add validation**  
+   Implement sanity checks for required parameters
 
----
-
-### **3. Rebuild the Plugin**
-
-Rebuild the plugin using `xcaddy` to include your new fetcher:
-
-```bash
-xcaddy build --with github.com/jasonlovesdoggo/caddy-defender
-```
+4. **Update documentation**  
+   Document your handler in:
+   - Caddyfile syntax examples
+   - JSON configuration reference
+   - Responder type matrix
 
 ---
 
-### **4. Test the Changes**
+## **General Contribution Guidelines**
 
-Run Caddy with your updated configuration and verify that the new IP ranges are blocked or manipulated as expected.
+1. **Testing**  
+   Include unit tests for new features using the standard Go testing framework
 
----
+2. **Documentation**  
+   Keep both developer and user documentation updated
 
-## **Dynamic IP Range Fetching**
+3. **Backwards Compatibility**  
+   Maintain existing functionality unless deprecating features
 
-If your service provides an API to fetch IP ranges dynamically, you can use HTTP requests and JSON parsing (like in `OpenAIFetcher`). Here’s an example:
+4. **Code Style**  
+   Follow existing patterns and Go community standards
 
-```go
-package fetchers
-
-import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-)
-
-// MyServiceFetcher implements the IPRangeFetcher interface for MyService.
-type MyServiceFetcher struct{}
-
-func (f MyServiceFetcher) Name() string {
-	return "MyService"
-}
-
-func (f MyServiceFetcher) Description() string {
-	return "Fetches IP ranges for MyService."
-}
-
-func (f MyServiceFetcher) FetchIPRanges() ([]string, error) {
-	// Fetch IP ranges from an API
-	url := "https://api.myservice.com/ip-ranges"
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch IP ranges from %s: %v", url, err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body from %s: %v", url, err)
-	}
-
-	var ipRanges struct {
-		Prefixes []string `json:"prefixes"`
-	}
-	if err := json.Unmarshal(body, &ipRanges); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON from %s: %v", url, err)
-	}
-
-	return ipRanges.Prefixes, nil
-}
-```
+5. **Security Considerations**  
+   Highlight any security implications in pull requests
 
 ---
 
-## **Adding New Responders**
+## **Getting Started**
 
-Responders are responsible for handling requests that match the specified IP ranges. To add a new responder:
+1. Fork the repository
+2. Create a feature branch
+3. Implement your changes
+4. Add/update tests
+5. Update documentation
+6. Submit a pull request
 
-1. **Create a New Responder File**:
-   Create a new file in the `caddy-plugin/responders` directory, e.g., `my_responder.go`.
+For complex changes, please open an issue first to discuss the implementation approach.
 
-2. **Implement the Responder Interface**:
-   Your responder must implement the `Responder` interface:
-   ```go
-   package responders
+---
 
-   import "net/http"
+## **Need Help?**
 
-   type MyResponder struct {
-       // Add any fields you need here
-   }
+Reach out through:
+- GitHub Issues
+- Email: caddydefender@jasoncameron.dev
 
-   func (m MyResponder) Respond(w http.ResponseWriter, r *http.Request) error {
-       // Implement your custom response logic here
-       w.WriteHeader(http.StatusOK)
-       _, err := w.Write([]byte("This is my custom responder!"))
-       return err
-   }
-   ```
-
-3. **Register the Responder**:
-   Update the `UnmarshalCaddyfile` method in `caddy-plugin/plugin.go` to support your new responder:
-   ```go
-   func (m *Defender) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-       for d.Next() {
-           for d.NextArg() {
-               m.Ranges = append(m.Ranges, d.Val())
-           }
-
-           if d.NextArg() {
-               switch d.Val() {
-               case "block":
-                   m.responder = responders.BlockResponder{}
-               case "garbage":
-                   m.responder = responders.GarbageResponder{}
-               case "custom":
-                   if !d.NextArg() {
-                       return d.ArgErr()
-                   }
-                   m.responder = responders.CustomResponder{Message: d.Val()}
-               case "my_responder": // Add your new responder here
-                   m.responder = responders.MyResponder{}
-               default:
-                   return d.Errf("unknown responder: %s", d.Val())
-               }
-           }
-       }
-       return nil
-   }
-   ```
-
-4. **Test Your Responder**:
-   Add tests for your responder in a `_test.go` file and run them:
-   ```bash
-   go test ./...
-   ```
-
-5. **Update the Caddyfile Documentation**:
-   Add your new responder to the `README.md` and `docs/index.md` so users know how to use it.
+We appreciate your contributions to making Caddy Defender more powerful and flexible!

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     xcaddy build \
     --with github.com/jasonlovesdoggo/caddy-defender
 
-
 FROM caddy:latest
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ defender <responder> {
   - `block`: Returns a `403 Forbidden` response.
   - `garbage`: Returns garbage data to pollute AI training.
   - `custom`: Returns a custom message (requires `responder_args`).
+  - `ratelimit`: Marks requests for rate limiting (requires [Caddy-Ratelimit](https://github.com/mholt/caddy-ratelimit) to be installed as well ).
 - `<ip_ranges...>`: A list of CIDR ranges or predefined range keys (e.g., `openai`, `localhost`) to match against the client's IP.
 - `<custom message>`: A custom message to return when using the `custom` responder.
 ---

--- a/README.md
+++ b/README.md
@@ -86,41 +86,8 @@ defender <responder> {
 - `<custom message>`: A custom message to return when using the `custom` responder.
 ---
 
-### **Examples**
 
-#### **Block Requests**
-Block requests from specific IP ranges:
-```caddyfile
-localhost:8080 {
-    defender block {
-        range 203.0.113.0/24 openai 198.51.100.0/24 
-    } 
-    respond "Hello, world!" # what humans see
-}
-```
-
-#### **Return Garbage Data**
-Return garbage data for requests from specific IP ranges:
-```caddyfile
-localhost:8081 {
-    defender garbage {
-        range 192.168.0.0/24 
-    }
-    respond "Hello, world!" # what humans see
-}
-```
-
-#### **Custom Response**
-Return a custom message for requests from specific IP ranges:
-```caddyfile
-localhost:8082 {
-    defender custom {
-        message "Custom response message"
-        range 10.0.0.0/8
-    } 
-    respond "Hello, world!" # what humans see
-} 
-```
+## For examples, check out [docs/examples.md](docs/examples.md)
 
 ---
 
@@ -128,28 +95,21 @@ localhost:8082 {
 
 The plugin includes predefined IP ranges for popular AI services. These ranges are embedded in the binary and can be used without additional configuration.
 
-| Service             | IP Ranges                                    |
-|---------------------|----------------------------------------------|
-| OpenAI              | [openai.go](ranges/fetchers/openai.go)       |
-| DeepSeek            | [deepseek.go](ranges/fetchers/deepseek.go)   |
-| GitHub Copilot      | [github.go](ranges/fetchers/github.go)       |
-| Microsoft Azure     | [azure.go](ranges/fetchers/azure.go)         |
-| Localhost (testing) | [localhost.go](ranges/fetchers/localhost.go) | 
-| AWS                 | [aws.go](ranges/fetchers/aws/aws.go)         | 
+| Service             | IP Ranges                                          |
+|---------------------|----------------------------------------------------|
+| OpenAI              | [openai.go](ranges/fetchers/openai.go)             |
+| DeepSeek            | [deepseek.go](ranges/fetchers/deepseek.go)         |
+| GitHub Copilot      | [github.go](ranges/fetchers/github.go)             |
+| Microsoft Azure     | [azure.go](ranges/fetchers/azure.go)               |
+| Localhost (testing) | [localhost.go](ranges/fetchers/localhost.go)       | 
+| AWS                 | [aws.go](ranges/fetchers/aws/aws.go)               | 
 | AWS Region          | [aws_region.go](ranges/fetchers/aws/aws_region.go) |
 
 More are welcome! for a precompiled list, see the [embedded results](ranges/data/generated.go)
 
 ## **Contributing**
 
-We welcome contributions! Here’s how you can get started:
-
-### Adding New IP Ranges
-To add new IP ranges, you need to create a new fetcher in the `ranges/fetchers` package. Follow the steps in the [Contributing Guide](CONTRIBUTING.md).
-
-### Adding a New Responder
-
-To add a new responder, you need to create a new responder in the `responders` package and update the `UnmarshalCaddyfile` method in the `Defender` struct to handle the new responder. Follow the steps in the [Contributing Guide](CONTRIBUTING.md).
+We welcome contributions! To get started, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 

--- a/config.go
+++ b/config.go
@@ -81,6 +81,8 @@ func (m *Defender) UnmarshalJSON(b []byte) error {
 		m.responder = &responders.CustomResponder{
 			Message: m.Message,
 		}
+	case "ratelimit":
+		m.responder = &responders.RateLimitResponder{}
 	default:
 		return fmt.Errorf("unknown responder type: %s", rawConfig.RawResponder)
 	}

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ import (
 	"slices"
 )
 
-var responderTypes = []string{"block", "garbage", "custom"}
+var responderTypes = []string{"block", "garbage", "custom", "ratelimit"}
 
 // UnmarshalCaddyfile sets up the handler from Caddyfile tokens. Syntax:
 //

--- a/development/main.go
+++ b/development/main.go
@@ -34,6 +34,7 @@ import (
 	// plug in Caddy modules here
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 	_ "github.com/jasonlovesdoggo/caddy-defender"
+	_ "github.com/mholt/caddy-ratelimit"
 )
 
 func main() {

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -76,30 +76,32 @@ localhost:8080 {
 #### **Rate Limiting**
 Integrate with [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit):
 ```caddyfile
-example.com {
-    defender ratelimit {
-        ranges cloudflare
-        rate_limit_header X-API-Limit
-    }
-    
-    ratelimit {
-        match header X-API-Limit true # required, otherwise ratelimit will not work
-        rate 5r/s # example rate limit
-        burst 10 # example burst limit
-    }
-    
-    respond "API Response"
+{
+	order rate_limit after basic_auth
 }
 
-# JSON equivalent
-{
-    "handler": "defender",
-    "raw_responder": "ratelimit",
-    "ranges": ["cloudflare"],
-    "rate_limit_header": "X-API-Limit"
+:80 {
+	defender ratelimit {
+		ranges localhost
+	}
+    
+	rate_limit {
+		zone static_example {
+			match {
+				method GET
+				header X-RateLimit-Apply true
+			}
+			key {remote_host}
+			events 3
+			window 1m
+		}
+	}
+
+	respond "Hey I'm behind a rate limit!"
 }
 ```
-For complete rate limiting documentation, see [RATELIMIT.md](./ratelimit.md).
+For complete rate limiting documentation,
+see [RATELIMIT.md](./ratelimit.md) and [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit).
 
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,124 @@
+#### **Responder Types**
+
+Caddy Defender supports multiple response strategies:
+
+| Responder   | Description                                                               | Configuration Required       |
+|-------------|---------------------------------------------------------------------------|------------------------------|
+| `block`     | Immediately blocks requests with 403 Forbidden                            | No                           |
+| `garbage`   | Returns random garbage data to confuse scrapers/AI                        | No                           |
+| `custom`    | Returns a custom text response                                            | `message` field required     |
+| `ratelimit` | Marks requests for rate limiting (requires `caddy-ratelimit` integration) | Additional rate limit config |
+
+---
+
+#### **Block Requests**
+Block requests from specific IP ranges with 403 Forbidden:
+```caddyfile
+localhost:8080 {
+    defender block {
+        ranges 203.0.113.0/24 openai 198.51.100.0/24 
+    } 
+    respond "Human-friendly content"
+}
+
+# JSON equivalent
+{
+    "handler": "defender",
+    "raw_responder": "block",
+    "ranges": ["203.0.113.0/24", "openai"]
+}
+```
+
+---
+
+#### **Return Garbage Data**
+Return meaningless content for AI/scrapers:
+```caddyfile
+localhost:8080 {
+    defender garbage {
+        ranges 192.168.0.0/24 
+    }
+    respond "Legitimate content"
+}
+
+# JSON equivalent
+{
+    "handler": "defender",
+    "raw_responder": "garbage",
+    "ranges": ["192.168.0.0/24"]
+}
+```
+
+---
+
+#### **Custom Response**
+Return tailored messages for blocked requests:
+```caddyfile
+localhost:8080 {
+    defender custom {
+        ranges 10.0.0.0/8
+        message "Access restricted for your network"
+    } 
+    respond "Public content"
+}
+
+# JSON equivalent
+{
+    "handler": "defender",
+    "raw_responder": "custom",
+    "ranges": ["10.0.0.0/8"],
+    "message": "Access restricted for your network"
+}
+```
+
+---
+
+#### **Rate Limiting**
+Integrate with [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit):
+```caddyfile
+example.com {
+    defender ratelimit {
+        ranges cloudflare
+        rate_limit_header X-API-Limit
+    }
+    
+    ratelimit {
+        match header X-API-Limit true # required, otherwise ratelimit will not work
+        rate 5r/s # example rate limit
+        burst 10 # example burst limit
+    }
+    
+    respond "API Response"
+}
+
+# JSON equivalent
+{
+    "handler": "defender",
+    "raw_responder": "ratelimit",
+    "ranges": ["cloudflare"],
+    "rate_limit_header": "X-API-Limit"
+}
+```
+For complete rate limiting documentation, see [RATELIMIT.md](./ratelimit.md).
+
+---
+
+#### **Combination Example**
+Mix multiple response strategies:
+```caddyfile
+example.com {
+    defender block {
+        ranges known-bad-actors
+    }
+    
+    defender ratelimit {
+        ranges aws
+    }
+    
+    defender garbage {
+        ranges scrapers
+    }
+    
+    respond "Main Website Content"
+}
+```

--- a/docs/ratelimit.md
+++ b/docs/ratelimit.md
@@ -8,13 +8,11 @@
 ```caddy
 defender ratelimit {
     ranges <cidr_or_predefined...>
-    # Optional rate limit marker header (default: X-Defender-RateLimit)
-    rate_limit_header <header-name>
 }
 
 ratelimit {
     # Match requests marked by Defender
-    match header <header-name> <value>
+    match header X-Defender-RateLimit true
     
     # Rate limiting parameters
     rate  <requests-per-second>

--- a/docs/ratelimit.md
+++ b/docs/ratelimit.md
@@ -1,0 +1,145 @@
+# Defender Module - Rate Limiting Integration Guide
+
+**Feature:** Match requests by IP range and apply rate limiting using [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit)
+
+## Configuration Overview
+
+### Caddyfile Syntax
+```caddy
+defender ratelimit {
+    ranges <cidr_or_predefined...>
+    # Optional rate limit marker header (default: X-Defender-RateLimit)
+    rate_limit_header <header-name>
+}
+
+ratelimit {
+    # Match requests marked by Defender
+    match header <header-name> <value>
+    
+    # Rate limiting parameters
+    rate  <requests-per-second>
+    burst <burst-size>
+    key   <rate-limit-key>
+}
+```
+
+### JSON Configuration
+```json
+{
+    "handler": "defender",
+    "raw_responder": "ratelimit",
+    "ranges": ["aws", "10.0.0.0/8"],
+    "rate_limit_header": "X-Defender-RateLimit"
+}
+```
+
+## Example Configurations
+
+### Basic Configuration
+```caddy
+example.com {
+    defender ratelimit {
+        ranges cloudflare openai
+    }
+    
+    ratelimit {
+        match header X-Defender-RateLimit true
+        rate  5r/s
+        burst 10
+        key   {http.request.remote.host}
+    }
+    
+    respond "Hello World"
+}
+```
+
+### Advanced Configuration
+```caddy
+api.example.com {
+    defender ratelimit {
+        ranges 192.168.1.0/24 azure
+        rate_limit_header X-API-RateLimit
+    }
+    
+    ratelimit {
+        match header X-API-RateLimit true
+        rate  10r/s
+        burst 20
+        key   {http.request.uri.path}
+        
+        # Optional: Custom response
+        respond {
+            status_code 429
+            body "Too Many Requests - Try Again Later"
+        }
+    }
+    
+    reverse_proxy localhost:3000
+}
+```
+
+## Documentation
+
+### Directives
+
+**Defender Rate Limit Responder:**
+- `ranges` - IP ranges to apply rate limiting (CIDR or predefined)
+- `rate_limit_header` (optional) - Header to mark requests for rate limiting (default: `X-Defender-RateLimit`)
+
+**Rate Limit Module:**
+- `match header` - Match the header set by Defender
+- `rate` - Requests per second (e.g., `10r/s`)
+- `burst` - Allow temporary bursts of requests
+- `key` - Rate limit key (typically client IP or path)
+
+### How It Works
+1. **IP Matching:** Defender checks if client IP matches configured ranges
+2. **Header Marking:** Matching requests get a header (`X-Defender-RateLimit: true`)
+3. **Rate Limiting:** caddy-ratelimit applies limits only to marked requests
+4. **Request Processing:** Non-matched requests bypass rate limiting
+
+### Use Cases
+- Protect API endpoints from scraping
+- Mitigate brute force attacks
+- Enforce different rate limits for:
+  - Different geographic regions
+  - Known bot networks
+  - Internal vs external traffic
+
+### Requirements
+
+- [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit) module installed
+- [caddy-defender](https://github.com/JasonLovesDoggo/caddy-defender) v0.5.0+
+
+### Notes
+1. **Order Matters:** Defender must come before ratelimit in handler chain
+2. **Header Customization:** Change header name if conflicts occur
+3. **Combination with Other Protections:**
+   ```caddy
+   defender ratelimit {
+       ranges aws
+   }
+   
+   ratelimit {
+       match header X-Defender-RateLimit true
+       rate 2r/s
+   }
+   
+   defender block {
+       ranges known-bad-ips
+   }
+   ```
+
+### Troubleshooting
+1. **Check Headers:**
+   ```bash
+   curl -I http://example.com
+   ```
+2. **Verify Handler Order:** Defender → Ratelimit → Other handlers
+3. **Test Rate Limits:**
+   ```bash
+   # Simulate requests from blocked range
+   for i in {1..20}; do
+       curl -H "X-Forwarded-For: 20.202.43.67" http://example.com
+   done
+   ```

--- a/examples/ratelimit/Caddyfile
+++ b/examples/ratelimit/Caddyfile
@@ -1,0 +1,23 @@
+{
+	order rate_limit after basic_auth
+}
+
+:80 {
+	defender ratelimit {
+		ranges localhost
+	}
+
+	rate_limit {
+		zone static_example {
+			match {
+				method GET
+				header X-RateLimit-Apply true
+			}
+			key {remote_host}
+			events 3
+			window 1m
+		}
+	}
+
+	respond "Hey I'm behind a rate limit!"
+}

--- a/examples/ratelimit/README.md
+++ b/examples/ratelimit/README.md
@@ -1,0 +1,1 @@
+# NOTE! This requires the [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit) module to be installed. 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/caddyserver/caddy/v2 v2.9.1
 	github.com/gaissmai/bart v0.17.8
+	github.com/mholt/caddy-ratelimit v0.1.0
 	github.com/stretchr/testify v1.10.0
 	github.com/viccon/sturdyc v1.1.1
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mholt/acmez/v3 v3.0.0 h1:r1NcjuWR0VaKP2BTjDK9LRFBw/WvURx3jlaEUl9Ht8E=
 github.com/mholt/acmez/v3 v3.0.0/go.mod h1:L1wOU06KKvq7tswuMDwKdcHeKpFFgkppZy/y0DFxagQ=
+github.com/mholt/caddy-ratelimit v0.1.0 h1:73lOvdSLSoBGPT5l61nrTzh9liax+IDfXeQDtfzNcZ4=
+github.com/mholt/caddy-ratelimit v0.1.0/go.mod h1:smAiS3nAflvLDTiGNKUlPXG47Ke3bAiexcWWipVzvMY=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
 github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=

--- a/middleware.go
+++ b/middleware.go
@@ -27,7 +27,7 @@ func (m Defender) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	// Check if the client IP is in any of the ranges using the optimized checker
 	if m.ipChecker.IPInRanges(r.Context(), clientIP) {
 		m.log.Debug("IP is in ranges", zap.String("ip", clientIP.String()))
-		return m.responder.Respond(w, r)
+		return m.responder.ServeHTTP(w, r, next)
 	} else {
 		m.log.Debug("IP is not in ranges", zap.String("ip", clientIP.String()))
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -6,6 +6,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/jasonlovesdoggo/caddy-defender/ranges/data"
+	"github.com/jasonlovesdoggo/caddy-defender/responders"
 	"github.com/jasonlovesdoggo/caddy-defender/utils/ip"
 	"go.uber.org/zap"
 	"maps"
@@ -69,7 +70,7 @@ type Defender struct {
 	RawResponder string `json:"raw_responder,omitempty"`
 
 	// responder is the internal implementation of the response strategy
-	responder Responder
+	responder responders.Responder
 	ipChecker *ip.IPChecker
 	log       *zap.Logger
 }

--- a/responder.go
+++ b/responder.go
@@ -1,10 +1,11 @@
 package caddydefender
 
 import (
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"net/http"
 )
 
 // Responder defines the interface for handling responses.
 type Responder interface {
-	Respond(w http.ResponseWriter, r *http.Request) error
+	ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error
 }

--- a/responders/block.go
+++ b/responders/block.go
@@ -1,13 +1,14 @@
 package responders
 
 import (
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"net/http"
 )
 
 // BlockResponder blocks the request with a 403 Forbidden response.
 type BlockResponder struct{}
 
-func (b BlockResponder) Respond(w http.ResponseWriter, r *http.Request) error {
+func (b BlockResponder) ServeHTTP(w http.ResponseWriter, _ *http.Request, _ caddyhttp.Handler) error {
 	w.WriteHeader(http.StatusForbidden)
 	_, err := w.Write([]byte("Access denied"))
 	return err

--- a/responders/custom.go
+++ b/responders/custom.go
@@ -1,6 +1,7 @@
 package responders
 
 import (
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"net/http"
 )
 
@@ -9,7 +10,7 @@ type CustomResponder struct {
 	Message string `json:"message"`
 }
 
-func (c CustomResponder) Respond(w http.ResponseWriter, _ *http.Request) error {
+func (c CustomResponder) ServeHTTP(w http.ResponseWriter, _ *http.Request, _ caddyhttp.Handler) error {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte(c.Message))

--- a/responders/garbage.go
+++ b/responders/garbage.go
@@ -1,6 +1,7 @@
 package responders
 
 import (
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"math/rand"
 	"net/http"
 	"strings"
@@ -9,7 +10,7 @@ import (
 // GarbageResponder returns garbage data to the client.
 type GarbageResponder struct{}
 
-func (g GarbageResponder) Respond(w http.ResponseWriter, r *http.Request) error {
+func (g GarbageResponder) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.Handler) error {
 	garbage := generateTerribleText(100)
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)

--- a/responders/ratelimit.go
+++ b/responders/ratelimit.go
@@ -1,0 +1,16 @@
+package responders
+
+import (
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"net/http"
+)
+
+type RateLimitResponder struct {
+}
+
+func (r *RateLimitResponder) ServeHTTP(w http.ResponseWriter, req *http.Request, next caddyhttp.Handler) error {
+	req.Header.Set("X-RateLimit-Apply", "true")
+
+	// Continue with the handler chain
+	return next.ServeHTTP(w, req)
+}

--- a/responders/responder.go
+++ b/responders/responder.go
@@ -1,4 +1,4 @@
-package caddydefender
+package responders
 
 import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"


### PR DESCRIPTION
This commit integrates the Defender module with the caddy-ratelimit
module to enable rate limiting based on IP ranges.  Defender now
marks requests from specified IP ranges with a header, and the
ratelimit module applies rate limiting only to requests with that
header.  This allows for flexible rate limiting based on IP ranges
or other criteria.

fixes #23