### PR TITLE
Potential fix for code scanning alert no. 7: Missing regular expression anchor

### DIFF
--- a/ranges/fetchers/azure.go
+++ b/ranges/fetchers/azure.go
@@ -35,7 +35,7 @@ func (f AzurePublicCloudFetcher) FetchIPRanges() ([]string, error) {
 	}
 
 	// Step 2: Extract the JSON download URL using a regex
-	urlRegex := regexp.MustCompile(`https://download\.microsoft\.com/.*?\.json`)
+	urlRegex := regexp.MustCompile(`^https://download\.microsoft\.com/.*?\.json$`)
 	matches := urlRegex.FindStringSubmatch(string(body))
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("failed to find JSON download URL in Azure download page")


### PR DESCRIPTION
Potential fix for [https://github.com/JasonLovesDoggo/caddy-defender/security/code-scanning/7](https://github.com/JasonLovesDoggo/caddy-defender/security/code-scanning/7)

To fix the problem, we need to anchor the regular expression to ensure it matches the entire URL string from the beginning to the end. This can be done by adding `^` at the start and `$` at the end of the regular expression. This ensures that the URL must start with `https://download.microsoft.com/` and end with `.json`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
