### PR TITLE
Add redirect responder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 
 # MaxMind DB files (for GeoIP blocklist)
 *.mmdb
+
+# compiled caddy binary
+caddy

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The **Caddy Defender** plugin is a middleware for Caddy that allows you to block
   - **Block**: Return a `403 Forbidden` response.
   - **Garbage**: Return garbage data to pollute AI training.
   - **Custom**: Return a custom message.
+  - **Redirect**: Return a `308 Permanent Redirect` response with a custom URL.
 
 ---
 
@@ -82,11 +83,11 @@ defender <responder> {
   - `block`: Returns a `403 Forbidden` response.
   - `garbage`: Returns garbage data to pollute AI training.
   - `custom`: Returns a custom message (requires `responder_args`).
+  - `redirect`: Returns a `308 Permanent Redirect` response (requires `responder_args`).
   - `ratelimit`: Marks requests for rate limiting (requires [Caddy-Ratelimit](https://github.com/mholt/caddy-ratelimit) to be installed as well ).
 - `<ip_ranges...>`: An optional list of CIDR ranges or predefined range keys to match against the client's IP. Defaults to [`aws azurepubliccloud deepseek gcloud githubcopilot openai`](./plugin.go).
 - `<custom message>`: A custom message to return when using the `custom` responder.
 ---
-
 
 ## For examples, check out [docs/examples.md](docs/examples.md)
 
@@ -122,6 +123,7 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 ---
 
 ## **Acknowledgments**
+
 - [The inspiration for this project](https://www.reddit.com/r/selfhosted/comments/1i154h7/comment/m73pj9t/).
 - [bart](https://github.com/gaissmai/bart) - [Karl Gaissmaier](https://github.com/gaissmai)'s efficient routing table implementation (Balanced ART adaptation) enabling our high-performance IP matching
 - Built with ❤️ using [Caddy](https://caddyserver.com).

--- a/config_test.go
+++ b/config_test.go
@@ -2,11 +2,12 @@ package caddydefender
 
 import (
 	"encoding/json"
+	"sort"
+	"testing"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/jasonlovesdoggo/caddy-defender/responders"
-	"sort"
-	"testing"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,18 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 				RawResponder: "custom",
 				Ranges:       []string{"openai"},
 				Message:      "Not allowed",
+			},
+		},
+		{
+			name: "valid redirect responder with url",
+			input: `defender redirect {
+				ranges openai
+				url "https://example.com"
+			}`,
+			expected: Defender{
+				RawResponder: "redirect",
+				Ranges:       []string{"openai"},
+				URL:          "https://example.com",
 			},
 		},
 		{
@@ -125,6 +138,16 @@ func TestUnmarshalJSON(t *testing.T) {
 				Message:      "Go away",
 				Ranges:       []string{"openai"},
 				responder:    &responders.CustomResponder{Message: "Go away"},
+			},
+		},
+		{
+			name:  "valid redirect responder with url",
+			input: `{"raw_responder":"redirect","url":"https://example.com","ranges":["openai"]}`,
+			expected: Defender{
+				RawResponder: "redirect",
+				URL:          "https://example.com",
+				Ranges:       []string{"openai"},
+				responder:    &responders.RedirectResponder{URL: "https://example.com"},
 			},
 		},
 		{

--- a/examples/redirect/Caddyfile
+++ b/examples/redirect/Caddyfile
@@ -1,0 +1,14 @@
+{
+	auto_https off
+	order defender after header
+	debug
+}
+
+:80 {
+	bind 127.0.0.1 ::1
+
+	defender redirect {
+		ranges private
+		url "https://example.com"
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -54,6 +54,7 @@ var (
 // - `block`: Immediately block requests with 403 Forbidden
 // - `garbage`: Respond with random garbage data
 // - `custom`: Return a custom message (requires `message` field)
+// - `redirect`: Redirect requests to a URL with 308 permanent redirect
 //
 // For a of predefined ranges, see the the [readme]
 // [readme]: https://github.com/JasonLovesDoggo/caddy-defender#embedded-ip-ranges
@@ -73,8 +74,12 @@ type Defender struct {
 	// Required only when using 'custom' responder.
 	Message string `json:"message,omitempty"`
 
+	// URL specifies the custom URL to redirect clients to for 'redirect' responder type.
+	// Required only when using 'redirect' responder.
+	URL string `json:"url,omitempty"`
+
 	// RawResponder defines the response strategy for blocked requests.
-	// Required. Must be one of: "block", "garbage", "custom"
+	// Required. Must be one of: "block", "garbage", "custom", "redirect"
 	RawResponder string `json:"raw_responder,omitempty"`
 
 	// ServeIgnore specifies whether to serve a robots.txt file with a "Disallow: /" directive

--- a/responders/redirect.go
+++ b/responders/redirect.go
@@ -1,0 +1,17 @@
+package responders
+
+import (
+	"net/http"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// RedirectResponder redirects a request with a 308 permanent redirect response.
+type RedirectResponder struct {
+	URL string
+}
+
+func (r *RedirectResponder) ServeHTTP(w http.ResponseWriter, req *http.Request, _ caddyhttp.Handler) error {
+	http.Redirect(w, req, r.URL, http.StatusPermanentRedirect)
+	return nil
+}


### PR DESCRIPTION
Addresses #39 

Super cool project!  I love the plugin and wanted to contribute to it :) 

This adds support for a `redirect` responder that allows users to specify a URL to redirect clients to with a `308 Permanent Response`. I also formatted the README a bit with newlines and added `caddy` to `.gitignore` as a result of testing with `xcaddy`.

I validated the change locally with this caddyfile:

```
{
	auto_https off
	order defender after header
	debug
}

:8080 {
	bind 127.0.0.1 ::1

	defender redirect {
		ranges private
		url "https://example.com"
	}
}
```

The resulting rsponse:

```
❯ curl http://localhost:8080 -v
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 308 Permanent Redirect
< Content-Type: text/html; charset=utf-8
< Location: https://example.com
< Server: Caddy
< Date: Sat, 01 Feb 2025 18:55:59 GMT
< Content-Length: 55
< 
<a href="https://example.com">Permanent Redirect</a>.

* Connection #0 to host localhost left intact
```
