### PR TITLE
add golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,21 @@ permissions:
   packages: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,4 @@
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment

--- a/config_test.go
+++ b/config_test.go
@@ -17,9 +17,9 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
+		errContains string
 		expected    Defender
 		expectError bool
-		errContains string
 	}{
 		{
 			name: "valid block responder with CIDR ranges",
@@ -70,24 +70,24 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 			input: `defender {
 				ranges 10.0.0.0/8
 			}`,
-			expectError: true,
 			errContains: "missing responder type",
+			expectError: true,
 		},
 		{
 			name: "invalid responder type",
 			input: `defender invalid {
 				ranges 10.0.0.0/8
 			}`,
-			expectError: true,
 			errContains: "invalid responder type",
+			expectError: true,
 		},
 		{
 			name: "invalid subdirective",
 			input: `defender block {
 				invalid 123
 			}`,
-			expectError: true,
 			errContains: "unknown subdirective",
+			expectError: true,
 		},
 	}
 

--- a/matchers/ip/ip_sanity_test.go
+++ b/matchers/ip/ip_sanity_test.go
@@ -22,51 +22,51 @@ func ipToAddrStd(ip net.IP) (netip.Addr, error) {
 
 func TestIPToAddrStd(t *testing.T) {
 	tests := []struct {
+		expected    netip.Addr
 		name        string
 		ip          net.IP
-		expected    netip.Addr
 		expectError bool
 	}{
 		{
+			expected:    netip.MustParseAddr("::ffff:192.168.1.1"),
 			name:        "Valid IPv4",
 			ip:          net.ParseIP("192.168.1.1"),
-			expected:    netip.MustParseAddr("::ffff:192.168.1.1"),
 			expectError: false,
 		},
 		{
+			expected:    netip.MustParseAddr("2001:db8::1"),
 			name:        "Valid IPv6",
 			ip:          net.ParseIP("2001:db8::1"),
-			expected:    netip.MustParseAddr("2001:db8::1"),
 			expectError: false,
 		},
 		{
+			expected:    netip.Addr{},
 			name:        "Nil IP",
 			ip:          nil,
-			expected:    netip.Addr{},
 			expectError: true,
 		},
 		{
+			expected:    netip.Addr{},
 			name:        "Empty IP",
 			ip:          net.IP{},
-			expected:    netip.Addr{},
 			expectError: true,
 		},
 		{
+			expected:    netip.Addr{},
 			name:        "Invalid IP (too short)",
 			ip:          net.IP{1, 2, 3}, // Invalid length
-			expected:    netip.Addr{},
 			expectError: true,
 		},
 		{
+			expected:    netip.Addr{},
 			name:        "Invalid IP (too long)",
 			ip:          net.IP{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}, // Invalid length
-			expected:    netip.Addr{},
 			expectError: true,
 		},
 		{
+			expected:    netip.MustParseAddr("::ffff:192.168.1.1"),
 			name:        "IPv4-Mapped IPv6",
 			ip:          net.ParseIP("::ffff:192.168.1.1"),
-			expected:    netip.MustParseAddr("::ffff:192.168.1.1"),
 			expectError: false,
 		},
 	}

--- a/matchers/ip/ip_test.go
+++ b/matchers/ip/ip_test.go
@@ -2,10 +2,11 @@ package ip
 
 import (
 	"context"
-	"go.uber.org/zap/zapcore"
 	"net"
 	"testing"
 	"time"
+
+	"go.uber.org/zap/zapcore"
 
 	"github.com/jasonlovesdoggo/caddy-defender/ranges/data"
 	"github.com/stretchr/testify/assert"
@@ -177,40 +178,40 @@ func TestPredefinedCIDRGroups(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		groups        []string
 		ip            string
+		groups        []string
 		expected      bool
 		expectedError bool
 	}{
 		{
 			name:     "IPv4 in predefined group",
-			groups:   []string{"cloud-providers"},
 			ip:       "203.0.113.42",
+			groups:   []string{"cloud-providers"},
 			expected: true,
 		},
 		{
 			name:     "IPv6 in predefined group",
-			groups:   []string{"cloud-providers"},
 			ip:       "2001:db8:1::42",
+			groups:   []string{"cloud-providers"},
 			expected: true,
 		},
 		{
 			name:     "IP not in group",
-			groups:   []string{"cloud-providers"},
 			ip:       "192.168.1.100",
+			groups:   []string{"cloud-providers"},
 			expected: false,
 		},
 		{
 			name:          "Nonexistent group",
-			groups:        []string{"invalid-group"},
 			ip:            "203.0.113.42",
+			groups:        []string{"invalid-group"},
 			expected:      false,
 			expectedError: true,
 		},
 		{
 			name:          "Empty group",
-			groups:        []string{"empty-group"},
 			ip:            "203.0.113.42",
+			groups:        []string{"empty-group"},
 			expected:      false,
 			expectedError: false,
 		},

--- a/matchers/whitelist/whitelist_test.go
+++ b/matchers/whitelist/whitelist_test.go
@@ -57,28 +57,28 @@ func TestWhitelisted(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
 		ip       netip.Addr
+		name     string
 		expected bool
 	}{
 		{
-			name:     "IPv4 in whitelist",
 			ip:       netip.MustParseAddr("192.168.1.1"),
+			name:     "IPv4 in whitelist",
 			expected: true,
 		},
 		{
-			name:     "IPv6 in whitelist",
 			ip:       netip.MustParseAddr("2001:db8::1"),
+			name:     "IPv6 in whitelist",
 			expected: true,
 		},
 		{
-			name:     "IPv4 not in whitelist",
 			ip:       netip.MustParseAddr("192.168.1.2"),
+			name:     "IPv4 not in whitelist",
 			expected: false,
 		},
 		{
-			name:     "IPv6 not in whitelist",
 			ip:       netip.MustParseAddr("2001:db8::2"),
+			name:     "IPv6 not in whitelist",
 			expected: false,
 		},
 	}

--- a/middleware.go
+++ b/middleware.go
@@ -2,9 +2,10 @@ package caddydefender
 
 import (
 	"fmt"
-	"go.uber.org/zap"
 	"net"
 	"net/http"
+
+	"go.uber.org/zap"
 
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
@@ -33,7 +34,7 @@ Disallow:
 User-agent: *
 Disallow: /
 `
-	w.Write([]byte(robotsTxt))
+	_, _ = w.Write([]byte(robotsTxt))
 	return true
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -59,17 +59,10 @@ var (
 // For a of predefined ranges, see the the [readme]
 // [readme]: https://github.com/JasonLovesDoggo/caddy-defender#embedded-ip-ranges
 type Defender struct {
-	// Ranges specifies IP ranges to block, which can be either:
-	// - CIDR notations (e.g., "192.168.1.0/24")
-	// - Predefined service keys (e.g., "openai", "aws")
-	// Default:
-	Ranges []string `json:"ranges,omitempty"`
-
-	// An optional whitelist of IP addresses to exclude from blocking. If empty, no IPs are whitelisted.
-	// NOTE: this only supports IP addresses, not ranges.
-	// Default: []
-	Whitelist []string `json:"whitelist,omitempty"`
-
+	// responder is the internal implementation of the response strategy
+	responder responders.Responder
+	ipChecker *ip.IPChecker
+	log       *zap.Logger
 	// Message specifies the custom response message for 'custom' responder type.
 	// Required only when using 'custom' responder.
 	Message string `json:"message,omitempty"`
@@ -82,13 +75,19 @@ type Defender struct {
 	// Required. Must be one of: "block", "garbage", "custom", "redirect"
 	RawResponder string `json:"raw_responder,omitempty"`
 
+	// Ranges specifies IP ranges to block, which can be either:
+	// - CIDR notations (e.g., "192.168.1.0/24")
+	// - Predefined service keys (e.g., "openai", "aws")
+	// Default:
+	Ranges []string `json:"ranges,omitempty"`
+	// An optional whitelist of IP addresses to exclude from blocking. If empty, no IPs are whitelisted.
+	// NOTE: this only supports IP addresses, not ranges.
+	// Default: []
+	Whitelist []string `json:"whitelist,omitempty"`
+
 	// ServeIgnore specifies whether to serve a robots.txt file with a "Disallow: /" directive
 	// Default: false
 	ServeIgnore bool `json:"serve_ignore,omitempty"`
-	// responder is the internal implementation of the response strategy
-	responder responders.Responder
-	ipChecker *ip.IPChecker
-	log       *zap.Logger
 }
 
 // Provision sets up the middleware and logger.


### PR DESCRIPTION
This PR adds linting to CI via [golangci-lint](https://github.com/golangci/golangci-lint). I added explicit configuration for [fieldalignment](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment) in govet. This ensures memory consumption is kept minimal by forcing optimal struct field sorting by way of eliminating unnecessary [struct padding](https://switchupcb.com/blog/implementing-the-fieldalignment-bundle-in-go/)