### PR TITLE
add validation for redirect responder to ensure url is set

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package caddydefender
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -156,6 +157,11 @@ func (m *Defender) Validate() error {
 	err := whitelist.Validate(m.Whitelist)
 	if err != nil {
 		return err
+	}
+
+	// Validate responder config options
+	if m.RawResponder == "redirect" && m.URL == "" {
+		return errors.New("redirect responder requires 'url' to be set")
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -307,4 +307,59 @@ func TestDefenderValidation(t *testing.T) {
   }
 }`, "json", "unknown responder type")
 	})
+
+	t.Run("Invalid responder type", func(t *testing.T) {
+		caddytest.AssertLoadError(t, `{
+    "admin": {
+      "disabled": true
+    },
+    "apps": {
+      "http": {
+        "servers": {
+          "srv0": {
+            "listen": [
+              "127.0.0.1:80",
+              "[::1]:80"
+            ],
+            "routes": [
+              {
+                "handle": [
+                  {
+                    "handler": "defender",
+                    "raw_responder": "redirect",
+                    "ranges": [
+                      "private"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "automatic_https": {
+              "disable": true
+            }
+          },
+          "srv1": {
+            "listen": [
+              "127.0.0.1:83",
+              "[::1]:83"
+            ],
+            "routes": [
+              {
+                "handle": [
+                  {
+                    "body": "Clear text HTTP",
+                    "handler": "static_response"
+                  }
+                ]
+              }
+            ],
+            "automatic_https": {
+              "disable": true
+            }
+          }
+        }
+      }
+    }
+  }`, "json", "redirect responder requires 'url' to be set")
+	})
 }

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,16 +8,19 @@ Caddy Defender supports multiple response strategies:
 | `garbage`   | Returns random garbage data to confuse scrapers/AI                        | No                           |
 | `custom`    | Returns a custom text response                                            | `message` field required     |
 | `ratelimit` | Marks requests for rate limiting (requires `caddy-ratelimit` integration) | Additional rate limit config |
+| `redirect` | Returns `308 Permanent Redirect` response                                  | `url` field required |
 
 ---
 
 #### **Block Requests**
+
 Block requests from specific IP ranges with 403 Forbidden:
+
 ```caddyfile
 localhost:8080 {
     defender block {
-        ranges 203.0.113.0/24 openai 198.51.100.0/24 
-    } 
+        ranges 203.0.113.0/24 openai 198.51.100.0/24
+    }
     respond "Human-friendly content"
 }
 
@@ -32,11 +35,13 @@ localhost:8080 {
 ---
 
 #### **Return Garbage Data**
+
 Return meaningless content for AI/scrapers:
+
 ```caddyfile
 localhost:8080 {
     defender garbage {
-        ranges 192.168.0.0/24 
+        ranges 192.168.0.0/24
     }
     respond "Legitimate content"
 }
@@ -52,13 +57,15 @@ localhost:8080 {
 ---
 
 #### **Custom Response**
+
 Return tailored messages for blocked requests:
+
 ```caddyfile
 localhost:8080 {
     defender custom {
         ranges 10.0.0.0/8
         message "Access restricted for your network"
-    } 
+    }
     respond "Public content"
 }
 
@@ -74,7 +81,9 @@ localhost:8080 {
 ---
 
 #### **Rate Limiting**
+
 Integrate with [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit):
+
 ```caddyfile
 {
 	order rate_limit after basic_auth
@@ -84,7 +93,7 @@ Integrate with [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit):
 	defender ratelimit {
 		ranges private
 	}
-    
+
 	rate_limit {
 		zone static_example {
 			match {
@@ -100,12 +109,37 @@ Integrate with [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit):
 	respond "Hey I'm behind a rate limit!"
 }
 ```
+
 For complete rate limiting documentation,
 see [RATELIMIT.md](./ratelimit.md) and [caddy-ratelimit](https://github.com/mholt/caddy-ratelimit).
 
 ---
 
+#### **Redirect Response**
+
+Redirect requests:
+
+```caddyfile
+localhost:8080 {
+    defender redirect {
+        ranges 10.0.0.0/8
+        url "https://example.com"
+    }
+}
+
+# JSON equivalent
+{
+    "handler": "defender",
+    "raw_responder": "redirect",
+    "ranges": ["10.0.0.0/8"],
+    "url": "https://example.com"
+}
+```
+
+---
+
 #### **Combination Example**
+
 Mix multiple response strategies:
 ```caddyfile
 example.com {


### PR DESCRIPTION
Validated locally:


Caddyfile:

```
{
	auto_https off
	order defender after header
	debug
}

:8080 {
	bind 127.0.0.1 ::1

	defender redirect {
		ranges private
	}
}
```

Result:

```
Error: loading initial config: loading new config: loading http app module: provision http: server srv0: setting up route handlers: route 0: loading handler modules: position 0: loading module 'defender': http.handlers.defender: invalid configuration: redirect responder requires 'url' to be set
2025/02/01 12:35:03 [ERROR] exit status 1
```