### PR TITLE
add drop responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The **Caddy Defender** plugin is a middleware for Caddy that allows you to block
 - **Custom IP Ranges**: Add your own IP ranges via Caddyfile configuration.
 - **Multiple Responder Backends**:
   - **Block**: Return a `403 Forbidden` response.
-  - **Garbage**: Return garbage data to pollute AI training.
   - **Custom**: Return a custom message.
+  - **Drop**: Drops the connection.
+  - **Garbage**: Return garbage data to pollute AI training.
   - **Redirect**: Return a `308 Permanent Redirect` response with a custom URL.
 
 ---
@@ -82,8 +83,9 @@ defender <responder> {
 
 - `<responder>`: The responder backend to use. Supported values are:
   - `block`: Returns a `403 Forbidden` response.
-  - `garbage`: Returns garbage data to pollute AI training.
   - `custom`: Returns a custom message (requires `message`).
+  - `drop`: Drops the connection.
+  - `garbage`: Returns garbage data to pollute AI training.
   - `redirect`: Returns a `308 Permanent Redirect` response (requires `url`).
   - `ratelimit`: Marks requests for rate limiting (requires [Caddy-Ratelimit](https://github.com/mholt/caddy-ratelimit) to be installed as well ).
 - `<ip_ranges...>`: An optional list of CIDR ranges or predefined range keys to match against the client's IP. Defaults to [`aws azurepubliccloud deepseek gcloud githubcopilot openai`](./plugin.go).

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jasonlovesdoggo/caddy-defender/responders"
 )
 
-var responderTypes = []string{"block", "garbage", "custom", "ratelimit", "redirect"}
+var responderTypes = []string{"block", "custom", "drop", "garbage", "ratelimit", "redirect"}
 
 // UnmarshalCaddyfile sets up the handler from Caddyfile tokens. Syntax:
 //
@@ -94,14 +94,16 @@ func (m *Defender) UnmarshalJSON(b []byte) error {
 	switch rawConfig.RawResponder {
 	case "block":
 		m.responder = &responders.BlockResponder{}
-	case "garbage":
-		m.responder = &responders.GarbageResponder{}
 	case "custom":
 		// Get the custom message
 		m.Message = rawConfig.Message
 		m.responder = &responders.CustomResponder{
 			Message: m.Message,
 		}
+	case "drop":
+		m.responder = &responders.DropResponder{}
+	case "garbage":
+		m.responder = &responders.GarbageResponder{}
 	case "ratelimit":
 		m.responder = &responders.RateLimitResponder{}
 	case "redirect":

--- a/config_test.go
+++ b/config_test.go
@@ -44,6 +44,16 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 			},
 		},
 		{
+			name: "valid drop responder",
+			input: `defender drop {
+				ranges openai
+			}`,
+			expected: Defender{
+				RawResponder: "drop",
+				Ranges:       []string{"openai"},
+			},
+		},
+		{
 			name: "valid redirect responder with url",
 			input: `defender redirect {
 				ranges openai
@@ -138,6 +148,15 @@ func TestUnmarshalJSON(t *testing.T) {
 				Message:      "Go away",
 				Ranges:       []string{"openai"},
 				responder:    &responders.CustomResponder{Message: "Go away"},
+			},
+		},
+		{
+			name:  "valid drop responder",
+			input: `{"raw_responder":"drop","ranges":["openai"]}`,
+			expected: Defender{
+				RawResponder: "drop",
+				Ranges:       []string{"openai"},
+				responder:    &responders.DropResponder{},
 			},
 		},
 		{

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,8 +5,9 @@ Caddy Defender supports multiple response strategies:
 | Responder   | Description                                                               | Configuration Required       |
 |-------------|---------------------------------------------------------------------------|------------------------------|
 | `block`     | Immediately blocks requests with 403 Forbidden                            | No                           |
-| `garbage`   | Returns random garbage data to confuse scrapers/AI                        | No                           |
 | `custom`    | Returns a custom text response                                            | `message` field required     |
+| `drop`      | Drops the connection                                                      | No                           |
+| `garbage`   | Returns random garbage data to confuse scrapers/AI                        | No                           |
 | `ratelimit` | Marks requests for rate limiting (requires `caddy-ratelimit` integration) | Additional rate limit config |
 | `redirect` | Returns `308 Permanent Redirect` response                                  | `url` field required |
 
@@ -34,28 +35,6 @@ localhost:8080 {
 
 ---
 
-#### **Return Garbage Data**
-
-Return meaningless content for AI/scrapers:
-
-```caddyfile
-localhost:8080 {
-    defender garbage {
-        ranges 192.168.0.0/24
-    }
-    respond "Legitimate content"
-}
-
-# JSON equivalent
-{
-    "handler": "defender",
-    "raw_responder": "garbage",
-    "ranges": ["192.168.0.0/24"]
-}
-```
-
----
-
 #### **Custom Response**
 
 Return tailored messages for blocked requests:
@@ -75,6 +54,49 @@ localhost:8080 {
     "raw_responder": "custom",
     "ranges": ["10.0.0.0/8"],
     "message": "Access restricted for your network"
+}
+```
+
+---
+
+#### **Drop connections**
+
+Drop connections rather than send a response:
+
+```caddyfile
+localhost:8080 {
+    defender drop {
+        ranges 203.0.113.0/24 openai 198.51.100.0/24
+    }
+}
+
+# JSON equivalent
+{
+    "handler": "defender",
+    "raw_responder": "drop",
+    "ranges": ["203.0.113.0/24", "openai"]
+}
+```
+
+---
+
+#### **Return Garbage Data**
+
+Return meaningless content for AI/scrapers:
+
+```caddyfile
+localhost:8080 {
+    defender garbage {
+        ranges 192.168.0.0/24
+    }
+    respond "Legitimate content"
+}
+
+# JSON equivalent
+{
+    "handler": "defender",
+    "raw_responder": "garbage",
+    "ranges": ["192.168.0.0/24"]
 }
 ```
 

--- a/examples/drop/Caddyfile
+++ b/examples/drop/Caddyfile
@@ -1,0 +1,13 @@
+{
+	auto_https off
+	order defender after header
+	debug
+}
+
+:80 {
+	bind 127.0.0.1 ::1
+
+	defender drop {
+		ranges private
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -52,8 +52,9 @@ var (
 //
 // Supported responder types:
 // - `block`: Immediately block requests with 403 Forbidden
-// - `garbage`: Respond with random garbage data
 // - `custom`: Return a custom message (requires `message` field)
+// - `drop`: Drops the connection
+// - `garbage`: Respond with random garbage data
 // - `redirect`: Redirect requests to a URL with 308 permanent redirect
 //
 // For a of predefined ranges, see the the [readme]

--- a/responders/drop.go
+++ b/responders/drop.go
@@ -1,0 +1,14 @@
+package responders
+
+import (
+	"net/http"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// DropResponder drops the connection.
+type DropResponder struct{}
+
+func (d *DropResponder) ServeHTTP(w http.ResponseWriter, _ *http.Request, _ caddyhttp.Handler) error {
+	panic(http.ErrAbortHandler)
+}


### PR DESCRIPTION
Address #42 

This adds a new `drop` responder that drops a connection rather than provides a response to prevent leaking server details. This is accomplished by using `panic()` + `http.ErrAbortHandler`. Docs from `http.ErrAbortHandler`:

```
// ErrAbortHandler is a sentinel panic value to abort a handler.
// While any panic from ServeHTTP aborts the response to the client,
// panicking with ErrAbortHandler also suppresses logging of a stack
// trace to the server's error log.
```

Validation:

Caddyfile:

```
{
	auto_https off
	order defender after header
	debug
}

:8080 {
	bind 127.0.0.1 ::1

	defender drop {
		ranges private
	}
}
```

Request/response:

```
❯ curl http://localhost:8080 -v
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
* Empty reply from server
* Closing connection
curl: (52) Empty reply from server
``` 

I also alphabetized the rest of the responder docs for tidiness. 