### PR TITLE
docs: fix incorrect syntax for ratelimit.md

### DIFF
--- a/docs/ratelimit.md
+++ b/docs/ratelimit.md
@@ -10,7 +10,7 @@ defender ratelimit {
     ranges <cidr_or_predefined...>
 }
 
-ratelimit {
+rate_limit {
     # Match requests marked by Defender
     match header X-Defender-RateLimit true
     
@@ -40,7 +40,7 @@ example.com {
         ranges cloudflare openai
     }
     
-    ratelimit {
+    rate_limit {
         match header X-Defender-RateLimit true
         rate  5r/s
         burst 10
@@ -59,7 +59,7 @@ api.example.com {
         rate_limit_header X-API-RateLimit
     }
     
-    ratelimit {
+    rate_limit {
         match header X-API-RateLimit true
         rate  10r/s
         burst 20
@@ -118,7 +118,7 @@ api.example.com {
        ranges aws
    }
    
-   ratelimit {
+   rate_limit {
        match header X-Defender-RateLimit true
        rate 2r/s
    }


### PR DESCRIPTION
I kept getting invalid Caddy config when I realized the syntax was incorrect for the `rate_limit` block. The examples are missing the underscore in the keyword 😅 

```hcl
example.com {

	defender ratelimit {
		ranges private aws azurepubliccloud deepseek gcloud githubcopilot openai
	}

	rate_limit {
		match header X-Defender-RateLimit true
		rate 5r/s
		burst 10
		key {http.request.remote.host}
	}
	reverse_proxy localhost:2586
```