### PR TITLE
Fix trusted proxy client IP matching

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -48,17 +48,11 @@ func (m Defender) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	if m.serveGitignore(w, r) {
 		return nil
 	}
-	// Split the RemoteAddr into IP and port
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		m.log.Error("Invalid client IP format", zap.String("ip", r.RemoteAddr))
-		return caddyhttp.Error(http.StatusForbidden, fmt.Errorf("invalid client IP format"))
-	}
 
-	clientIP := net.ParseIP(host)
-	if clientIP == nil {
-		m.log.Error("Invalid client IP", zap.String("ip", host))
-		return caddyhttp.Error(http.StatusForbidden, fmt.Errorf("invalid client IP"))
+	clientIP, err := clientIPFromRequest(r)
+	if err != nil {
+		m.log.Error("Invalid client IP", zap.String("remote_addr", r.RemoteAddr), zap.Error(err))
+		return caddyhttp.Error(http.StatusForbidden, err)
 	}
 	m.log.Debug("Ranges", zap.Strings("ranges", m.Ranges))
 
@@ -71,4 +65,24 @@ func (m Defender) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	m.log.Debug("Request blocked (IP in blocked ranges and not whitelisted)", zap.String("ip", clientIP.String()))
 	// Request should be blocked
 	return m.responder.ServeHTTP(w, r, next)
+}
+
+func clientIPFromRequest(r *http.Request) (net.IP, error) {
+	if clientIP, ok := caddyhttp.GetVar(r.Context(), caddyhttp.ClientIPVarKey).(string); ok && clientIP != "" {
+		return parseClientIP(clientIP)
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid client IP format")
+	}
+	return parseClientIP(host)
+}
+
+func parseClientIP(rawIP string) (net.IP, error) {
+	clientIP := net.ParseIP(rawIP)
+	if clientIP == nil {
+		return nil, fmt.Errorf("invalid client IP")
+	}
+	return clientIP, nil
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"pkg.jsn.cam/caddy-defender/responders"
@@ -224,4 +225,33 @@ func TestDefenderServeHTTP_RobotsFile(t *testing.T) {
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.Contains(t, recorder.Body.String(), "User-agent: *")
 	require.Contains(t, recorder.Body.String(), "Disallow: /")
+}
+
+// Regression test for GHSA-3h23-rrpc-3p87: Caddy resolves the real client IP
+// into ClientIPVarKey, and Defender must not fall back to the proxy RemoteAddr.
+func TestDefenderServeHTTP_UsesCaddyClientIP(t *testing.T) {
+	defender := &Defender{
+		RawResponder: "block",
+		Ranges:       []string{"203.0.113.0/24"},
+		responder:    &responders.BlockResponder{},
+	}
+
+	ctx := caddy.Context{Context: context.Background()}
+	defender.log = zap.NewNop()
+	err := defender.Provision(ctx)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "198.51.100.1:12345"
+	req = req.WithContext(context.WithValue(req.Context(), caddyhttp.VarsCtxKey, map[string]any{
+		caddyhttp.ClientIPVarKey: "203.0.113.10",
+	}))
+
+	recorder := httptest.NewRecorder()
+
+	err = defender.ServeHTTP(recorder, req, &mockHandler{})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Equal(t, "Access denied", recorder.Body.String())
 }


### PR DESCRIPTION
### Impact
Defender previously evaluated `r.RemoteAddr`, the immediate peer address, instead of Caddy's resolved `client_ip` request variable. In deployments behind a trusted proxy, CDN, or load balancer, a blocked client could be allowed when the direct proxy address was not in a blocked range. This is a bypass of Defender's IP-based blocking policy for affected proxy deployments.

### Patches
This patch makes Defender prefer Caddy's resolved `client_ip` value when present, with a fallback to `RemoteAddr` for direct request contexts. It also adds regression coverage for a blocked `client_ip` behind an unblocked direct peer.

Users should upgrade to the first release containing this patch.

### Workarounds
Before upgrading, users can block the proxy or load balancer IP ranges directly, but that is usually too broad and may block legitimate traffic. Deployments that do not rely on trusted proxy client IP resolution are less exposed.

### References
- Caddy request matcher documentation for `client_ip` and `remote_ip`: https://caddyserver.com/docs/caddyfile/matchers#client-ip
- Caddy `trusted_proxies` documentation: https://caddyserver.com/docs/caddyfile/options#trusted-proxies

### Validation
- `go test . -run TestDefenderServeHTTP_UsesCaddyClientIP -count=1`
- `go test ./...`
