### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.com/#JasonLovesDoggo/caddy-defender&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.dera.page/#JasonLovesDoggo/caddy-defender&Date)

--- a/docs/fetchers.md
+++ b/docs/fetchers.md
@@ -283,4 +283,4 @@ This module is licensed under the **MIT License**. See the [LICENSE](index.md#li
 
 ## **Star History**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.com/#JasonLovesDoggo/caddy-defender&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.dera.page/#JasonLovesDoggo/caddy-defender&Date)

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,4 +52,4 @@ This project is licensed under the **MIT License**. See the [LICENSE](https://gi
 
 ## **Star History**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.com/#JasonLovesDoggo/caddy-defender&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.dera.page/#JasonLovesDoggo/caddy-defender&Date)

--- a/ranges/README.md
+++ b/ranges/README.md
@@ -274,4 +274,4 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.com/#JasonLovesDoggo/caddy-defender&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JasonLovesDoggo/caddy-defender&type=Date)](https://star-history.dera.page/#JasonLovesDoggo/caddy-defender&Date)


### PR DESCRIPTION
The star history chart in the README and documentation is currently broken because of GitHub stargazer API restrictions, so the project's history no longer renders. This updates the chart link to a working alternative while keeping the same chart layout. No other behavior is changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL swaps with no runtime, security, or build impact.
> 
> **Overview**
> Replaces broken **Star History** embeds that pointed at `api.star-history.com` / `star-history.com` with the **`star-history.dera.page`** SVG and landing URLs so the chart renders again.
> 
> The same markdown badge update is applied in **`README.md`**, **`docs/index.md`**, **`docs/fetchers.md`**, and **`ranges/README.md`**; repo and chart type (`Date`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b7ad3344b5c451f32b134ae1240ffc149fc5bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->