### PR TITLE
feat: add Datadog IP range fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The plugin includes predefined IP ranges for popular AI services. These ranges a
 |                              Cloudflare                              |                 cloudflare                  |   [cloudflare.go](ranges/fetchers/cloudflare.go)   |
 |                            Digital Ocean                             |                digitalocean                 | [digitalocean.go](ranges/fetchers/digitalocean.go) |
 |                                Linode                                |                   linode                    |       [linode.go](ranges/fetchers/linode.go)       |
+|                               Datadog                                |                   datadog                   |      [datadog.go](ranges/fetchers/datadog.go)      |
 | [Private](https://caddyserver.com/docs/caddyfile/matchers#remote-ip) |                   private                   |      [private.go](ranges/fetchers/private.go)      |
 |                           All IP addresses                           |                     all                     |          [all.go](ranges/fetchers/all.go)          |
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -138,6 +138,7 @@ The plugin includes predefined IP ranges for popular AI services. These ranges a
 |                              Cloudflare                              |                 cloudflare                  |   [cloudflare.go](https://github.com/JasonLovesDoggo/caddy-defender/blob/main/ranges/fetchers/cloudflare.go)   |
 |                            Digital Ocean                             |                digitalocean                 | [digitalocean.go](https://github.com/JasonLovesDoggo/caddy-defender/blob/main/ranges/fetchers/digitalocean.go) |
 |                                Linode                                |                   linode                    |       [linode.go](https://github.com/JasonLovesDoggo/caddy-defender/blob/main/ranges/fetchers/linode.go)       |
+|                               Datadog                                |                   datadog                   |      [datadog.go](https://github.com/JasonLovesDoggo/caddy-defender/blob/main/ranges/fetchers/datadog.go)      |
 | [Private](https://caddyserver.com/docs/caddyfile/matchers#remote-ip) |                   private                   |      [private.go](https://github.com/JasonLovesDoggo/caddy-defender/blob/main/ranges/fetchers/private.go)      |
 |                           All IP addresses                           |                     all                     |          [all.go](https://github.com/JasonLovesDoggo/caddy-defender/blob/main/ranges/fetchers/all.go)          |
 

--- a/ranges/fetchers/datadog.go
+++ b/ranges/fetchers/datadog.go
@@ -1,0 +1,69 @@
+package fetchers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// DatadogFetcher implements the IPRangeFetcher interface for Datadog.
+type DatadogFetcher struct{}
+
+func (f DatadogFetcher) Name() string {
+	return "Datadog"
+}
+
+func (f DatadogFetcher) Description() string {
+	return "Fetches IP ranges used by Datadog services like the agent, APM, logs, and synthetics."
+}
+
+func (f DatadogFetcher) FetchIPRanges() ([]string, error) {
+	// https://docs.datadoghq.com/api/latest/ip-ranges/
+	const url = "https://ip-ranges.datadoghq.com/"
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Datadog IP ranges: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received non-200 status code from Datadog: %d", resp.StatusCode)
+	}
+
+	// The payload is keyed by service (agents, api, apm, logs, synthetics, ...)
+	// alongside a couple of metadata fields (version, modified). Decode into raw
+	// messages so new services get picked up automatically, and skip anything
+	// that doesn't fit the prefixes shape.
+	var payload map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal Datadog JSON: %v", err)
+	}
+
+	var ipRanges []string
+	for _, raw := range payload {
+		var prefixes struct {
+			PrefixesIPv4 []string `json:"prefixes_ipv4"`
+			PrefixesIPv6 []string `json:"prefixes_ipv6"`
+		}
+		if err := json.Unmarshal(raw, &prefixes); err != nil {
+			// version and modified are not objects, so they land here.
+			continue
+		}
+		ipRanges = append(ipRanges, prefixes.PrefixesIPv4...)
+		ipRanges = append(ipRanges, prefixes.PrefixesIPv6...)
+	}
+
+	// Services overlap and map iteration order isn't stable, so sort for a
+	// deterministic result and drop the duplicates that sorting makes adjacent.
+	sort.Strings(ipRanges)
+	unique := make([]string, 0, len(ipRanges))
+	for i, r := range ipRanges {
+		if i == 0 || r != ipRanges[i-1] {
+			unique = append(unique, r)
+		}
+	}
+
+	return unique, nil
+}

--- a/ranges/main.go
+++ b/ranges/main.go
@@ -52,6 +52,7 @@ func main() {
 		fetchers.CloudflareFetcher{},  // Cloudflare IP ranges
 		fetchers.AliyunFetcher{},      // Aliyun IP ranges
 		fetchers.HuaweiCloudFetcher{}, // Huawei Cloud IP ranges
+		fetchers.DatadogFetcher{},     // Datadog IP ranges
 	}
 
 	if fetchTor {


### PR DESCRIPTION
Closes #145. Adds a fetcher for Datadog's published IP ranges, pulling from https://ip-ranges.datadoghq.com/ and registering it under the `datadog` key alongside the other providers.

The endpoint groups prefixes by service (agents, apm, logs, synthetics, and so on) plus a couple of metadata fields, so I decode into raw messages, pull `prefixes_ipv4`/`prefixes_ipv6` out of anything that fits that shape, and skip the rest. That way new services get picked up without a code change. The services overlap, so I sort and dedupe the result. Ran it against the live endpoint and got 148 ranges back. Also added it to the two provider tables in the docs.